### PR TITLE
Search by indexer, get list of indexers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/request": "^2.48.1",
     "@types/request-promise": "^4.1.43",
     "request": "^2.88.0",
-    "request-promise": "^4.2.4"
+    "request-promise": "^4.2.4",
+    "xml-js": "^1.6.11"
   }
 }

--- a/src/responses/jackett.response.ts
+++ b/src/responses/jackett.response.ts
@@ -18,17 +18,21 @@ export interface JackettIndexerDetails {
   link: string;
   language: string;
   type: 'public' | 'private' | 'semi-private';
-  categories: [{
-    id: number,
-    name: string,
-  }];
-  searching: [{
-    search: SearchType,
-    tvSearch: SearchType,
-    movieSearch: SearchType,
-    musicSearch: SearchType,
-    audioSearch: SearchType,
-  }];
+  categories: [
+    {
+      id: number;
+      name: string;
+    }
+  ];
+  searching: [
+    {
+      search: SearchType;
+      tvSearch: SearchType;
+      movieSearch: SearchType;
+      musicSearch: SearchType;
+      audioSearch: SearchType;
+    }
+  ];
 }
 
 export interface JackettResult {

--- a/src/responses/jackett.response.ts
+++ b/src/responses/jackett.response.ts
@@ -6,6 +6,31 @@ export interface JackettIndexer {
   Error?: string;
 }
 
+interface SearchType {
+  available: string;
+  supportedParams: string;
+}
+export interface JackettIndexerDetails {
+  id: string;
+  configured: boolean;
+  title: string;
+  description: string;
+  link: string;
+  language: string;
+  type: 'public' | 'private' | 'semi-private';
+  categories: [{
+    id: number,
+    name: string,
+  }];
+  searching: [{
+    search: SearchType,
+    tvSearch: SearchType,
+    movieSearch: SearchType,
+    musicSearch: SearchType,
+    audioSearch: SearchType,
+  }];
+}
+
 export interface JackettResult {
   FirstSeen: Date;
   Tracker: string;

--- a/src/responses/jackett.response.ts
+++ b/src/responses/jackett.response.ts
@@ -7,30 +7,30 @@ export interface JackettIndexer {
 }
 
 interface SearchType {
-  available: string;
-  supportedParams: string;
+  Available: string;
+  SupportedParams: string;
 }
 export interface JackettIndexerDetails {
-  id: string;
-  configured: boolean;
-  title: string;
-  description: string;
-  link: string;
-  language: string;
-  type: 'public' | 'private' | 'semi-private';
-  categories: [
+  ID: string;
+  Configured: boolean;
+  Title: string;
+  Description: string;
+  Link: string;
+  Language: string;
+  Type: 'public' | 'private' | 'semi-private';
+  Categories: [
     {
-      id: number;
-      name: string;
+      ID: number;
+      Name: string;
     }
   ];
-  searching: [
+  Searching: [
     {
-      search: SearchType;
-      tvSearch: SearchType;
-      movieSearch: SearchType;
-      musicSearch: SearchType;
-      audioSearch: SearchType;
+      Search: SearchType;
+      TvSearch: SearchType;
+      MovieSearch: SearchType;
+      MusicSearch: SearchType;
+      AudioSearch: SearchType;
     }
   ];
 }

--- a/src/services/jackett.service.ts
+++ b/src/services/jackett.service.ts
@@ -1,8 +1,8 @@
 import * as request from 'request-promise';
 
-import {JackettIndexerDetails, JackettResponse, JackettResult} from '../responses/jackett.response';
+import { JackettIndexerDetails, JackettResponse, JackettResult } from '../responses/jackett.response';
 
-import {xml2js} from 'xml-js';
+import { xml2js } from 'xml-js';
 
 export class JackettService {
   constructor(private host: string, private apiKey: string) {}
@@ -18,10 +18,12 @@ export class JackettService {
     }).then(json => json);
   }
   public async searchRSS(query: string, indexer: string = 'all', categories?: number[]): Promise<JackettResult[]> {
-      const url =
-          `${this.host}/api/v2.0/indexers/${indexer}/results/torznab/api?apikey=${this.apiKey}&t=search&q=${encodeURIComponent(query)}` +
-          `${categories ? '&cat=' + categories.join(',') : ''}`;
-      return request(url).then(xml => xml2js(xml, {compact: true, nativeType: true})).then(((json: any) => {
+    const url =
+      `${this.host}/api/v2.0/indexers/${indexer}/results/torznab/api?apikey=${this.apiKey}&t=search` +
+      `&q=${encodeURIComponent(query)}` + `${categories ? '&cat=' + categories.join(',') : ''}`;
+    return request(url)
+      .then(xml => xml2js(xml, { compact: true, nativeType: true }))
+      .then((json: any) => {
         if (json.error) {
           return Promise.resolve([]);
         }
@@ -56,47 +58,47 @@ export class JackettService {
             CategoryDesc: '',
           };
         });
-      }));
+      });
   }
   public async getIndexers(configured: boolean = true): Promise<JackettIndexerDetails[]> {
-    return request({
-      url: `${this.host}/api/v2.0/indexers/all/results/torznab/api?apikey=${this.apiKey}&t=indexers&configured=${configured}`,
-    }).then(xml => xml2js(xml, {compact: true, nativeType: true})).then((json: any) => {
-      return json.indexers.indexer.map(indexer => {
-        const searching = indexer.caps.searching;
-        return {
-          id: indexer._attributes.id,
-          configured: indexer._attributes.configured,
-          title: indexer.title._text,
-          description: indexer.description._text,
-          link: indexer.link._text,
-          language: indexer.language._text,
-          type: indexer.type._text,
-          categories: [].concat(indexer.caps.categories.category).map(category => category._attributes),
-          searching: {
-            search: {
-              available: searching.search._attributes.available,
-              supportedParams: searching.search._attributes.supportedParams,
+    return request(`${this.host}/api/v2.0/indexers/all/results/torznab/api?apikey=${this.apiKey}&t=indexers&configured=${configured}`)
+      .then(xml => xml2js(xml, { compact: true, nativeType: true }))
+      .then((json: any) => {
+        return json.indexers.indexer.map(indexer => {
+          const searching = indexer.caps.searching;
+          return {
+            id: indexer._attributes.id,
+            configured: indexer._attributes.configured,
+            title: indexer.title._text,
+            description: indexer.description._text,
+            link: indexer.link._text,
+            language: indexer.language._text,
+            type: indexer.type._text,
+            categories: [].concat(indexer.caps.categories.category).map(category => category._attributes),
+            searching: {
+              search: {
+                available: searching.search._attributes.available,
+                supportedParams: searching.search._attributes.supportedParams,
+              },
+              tvSearch: {
+                available: searching['tv-search']._attributes.available,
+                supportedParams: searching['tv-search']._attributes.supportedParams,
+              },
+              movieSearch: {
+                available: searching['movie-search']._attributes.available,
+                supportedParams: searching['movie-search']._attributes.supportedParams,
+              },
+              musicSearch: {
+                available: searching['music-search']._attributes.available,
+                supportedParams: searching['music-search']._attributes.supportedParams,
+              },
+              audioSearch: {
+                available: searching['audio-search']._attributes.available,
+                supportedParams: searching['audio-search']._attributes.supportedParams,
+              },
             },
-            tvSearch: {
-              available: searching['tv-search']._attributes.available,
-              supportedParams: searching['tv-search']._attributes.supportedParams,
-            },
-            movieSearch: {
-              available: searching['movie-search']._attributes.available,
-              supportedParams: searching['movie-search']._attributes.supportedParams,
-            },
-            musicSearch: {
-              available: searching['music-search']._attributes.available,
-              supportedParams: searching['music-search']._attributes.supportedParams,
-            },
-            audioSearch: {
-              available: searching['audio-search']._attributes.available,
-              supportedParams: searching['audio-search']._attributes.supportedParams,
-            },
-          },
-        };
+          };
+        });
       });
-    });
   }
 }

--- a/src/services/jackett.service.ts
+++ b/src/services/jackett.service.ts
@@ -67,34 +67,39 @@ export class JackettService {
         return json.indexers.indexer.map(indexer => {
           const searching = indexer.caps.searching;
           return {
-            id: indexer._attributes.id,
-            configured: indexer._attributes.configured,
-            title: indexer.title._text,
-            description: indexer.description._text,
-            link: indexer.link._text,
-            language: indexer.language._text,
-            type: indexer.type._text,
-            categories: [].concat(indexer.caps.categories.category).map(category => category._attributes),
-            searching: {
-              search: {
-                available: searching.search._attributes.available,
-                supportedParams: searching.search._attributes.supportedParams,
+            ID: indexer._attributes.id,
+            Configured: indexer._attributes.configured,
+            Title: indexer.title._text,
+            Description: indexer.description._text,
+            Link: indexer.link._text,
+            Language: indexer.language._text,
+            Type: indexer.type._text,
+            Categories: [].concat(indexer.caps.categories.category).map(category => {
+              return {
+                ID: category._attributes.id,
+                Name: category._attributes.name,
+              };
+            }),
+            Searching: {
+              Search: {
+                Available: searching.search._attributes.available,
+                SupportedParams: searching.search._attributes.supportedParams,
               },
-              tvSearch: {
-                available: searching['tv-search']._attributes.available,
-                supportedParams: searching['tv-search']._attributes.supportedParams,
+              TvSearch: {
+                Available: searching['tv-search']._attributes.available,
+                SupportedParams: searching['tv-search']._attributes.supportedParams,
               },
-              movieSearch: {
-                available: searching['movie-search']._attributes.available,
-                supportedParams: searching['movie-search']._attributes.supportedParams,
+              MovieSearch: {
+                Available: searching['movie-search']._attributes.available,
+                SupportedParams: searching['movie-search']._attributes.supportedParams,
               },
-              musicSearch: {
-                available: searching['music-search']._attributes.available,
-                supportedParams: searching['music-search']._attributes.supportedParams,
+              MusicSearch: {
+                Available: searching['music-search']._attributes.available,
+                SupportedParams: searching['music-search']._attributes.supportedParams,
               },
-              audioSearch: {
-                available: searching['audio-search']._attributes.available,
-                supportedParams: searching['audio-search']._attributes.supportedParams,
+              AudioSearch: {
+                Available: searching['audio-search']._attributes.available,
+                SupportedParams: searching['audio-search']._attributes.supportedParams,
               },
             },
           };

--- a/src/services/jackett.service.ts
+++ b/src/services/jackett.service.ts
@@ -43,7 +43,7 @@ export class JackettService {
             Guid: item.guid._text,
             Link: item.link._text,
             Comments: item.comments._text,
-            Category: item.category.map(category => category._text),
+            Category: Array.isArray(item.category) && item.category.map(category => category._text),
             MagnetUri: torznabAttrs.magneturl,
             Imdb: torznabAttrs.imdb,
             Seeders: torznabAttrs.seeders,


### PR DESCRIPTION
I've added a few more methods to `jackett.service`:
- `getIndexers(configured: boolean = true)` - to get a list of all indexers
- `searchRSS(query: string, indexer: string = 'all', categories?: number[])`  - to search using a specific indexer