### PR TITLE
Added extra filtering parameters

### DIFF
--- a/src/responses/jackett.response.ts
+++ b/src/responses/jackett.response.ts
@@ -72,3 +72,10 @@ export interface JackettResponse {
   Results: JackettResult[];
   Indexers: JackettIndexer[];
 }
+
+export interface JackettFilteringParams {
+  offset?: number;
+  limit?: number;
+  ep?: number;
+  season?: number;
+}

--- a/src/services/jackett.service.ts
+++ b/src/services/jackett.service.ts
@@ -1,8 +1,15 @@
 import * as request from 'request-promise';
 
-import { JackettIndexerDetails, JackettResponse, JackettResult } from '../responses/jackett.response';
+import {
+  JackettFilteringParams,
+  JackettIndexerDetails,
+  JackettResponse,
+  JackettResult,
+} from '../responses/jackett.response';
 
 import { xml2js } from 'xml-js';
+
+import { ParsedUrlQueryInput, stringify } from 'querystring';
 
 export class JackettService {
   public Categories = {
@@ -71,12 +78,19 @@ export class JackettService {
    * @param {string} query Search string
    * @param {string} indexer Indexer to search
    * @param {number[]} categories Categories to include
+   * @param {JackettFilteringParams} extraParams
    */
-  public async searchRSS(query: string, indexer: string = 'all', categories?: number[]): Promise<JackettResult[]> {
+  public async searchRSS(
+    query: string,
+    indexer: string = 'all',
+    categories?: number[],
+    extraParams?: JackettFilteringParams,
+  ): Promise<JackettResult[]> {
     const url =
       `${this.host}/api/v2.0/indexers/${indexer}/results/torznab/api?apikey=${this.apiKey}&t=search` +
       `&q=${encodeURIComponent(query)}` +
-      `${categories ? '&cat=' + categories.join(',') : ''}`;
+      `${categories ? '&cat=' + categories.join(',') : ''}` +
+      `${extraParams ? '&' + stringify(extraParams as ParsedUrlQueryInput) : ''}`;
 
     return request(url)
       .then(xml => xml2js(xml, { compact: true, nativeType: true }))


### PR DESCRIPTION
Apparently Jackett also allows you to filter results by season and/or episode and it's also possible to limit them. This only works for the `torznab` API endpoint though (`searchRSS()` method).